### PR TITLE
Add sine graph example

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,4 +1,4 @@
-foreach(example rotate_square rotate_filled_pentagon)
+foreach(example draw_sine_graph rotate_square rotate_filled_pentagon)
     add_executable("${example}" "${example}.c")
     target_link_libraries("${example}" libdrawille)
 endforeach()

--- a/examples/draw_sine_graph.c
+++ b/examples/draw_sine_graph.c
@@ -1,0 +1,44 @@
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+
+#include "../src/Canvas.h"
+#include "../src/utils.h"
+
+#define radians(degrees) ((degrees) * M_PI / 180.0)
+
+int main(int argc, char** argv) {
+    size_t width, height;
+
+    if (!get_console_size(&width, &height)) {
+        return 1;
+    }
+
+    Canvas* c = new_canvas(width, height);
+
+    struct timespec wait, remaining;
+    wait.tv_sec = 0;
+    wait.tv_nsec = 100000000;
+
+    char** buffer = new_buffer(c);
+
+    while (1) {
+        fill(c, BLACK);
+        for (int x = 0; x <= 1800; x += 10) {
+            set_pixel(c, WHITE, x / 10, 10 + sin(radians(x)) * 10);
+        }
+
+        draw(c, buffer);
+        for (size_t i = 0; buffer[i] != NULL; i++) {
+            printf("%s\n", buffer[i]);
+        }
+
+        nanosleep(&wait, &remaining);
+    }
+
+    free_buffer(buffer);
+    free_canvas(c);
+
+    return 0;
+}

--- a/examples/draw_sine_graph.c
+++ b/examples/draw_sine_graph.c
@@ -31,7 +31,10 @@ int main(int argc, char** argv) {
 
         draw(c, buffer);
         for (size_t i = 0; buffer[i] != NULL; i++) {
-            printf("%s\n", buffer[i]);
+            printf("%s", buffer[i]);
+            if (buffer[i + 1] != NULL) {
+                printf("\n");
+            }
         }
 
         nanosleep(&wait, &remaining);


### PR DESCRIPTION
The graph seems to be missing its top part.

I ported this code from [@asiimoo/drawille's README](https://github.com/asciimoo/drawille#readme):
```python
from __future__ import print_function
from drawille import Canvas
from math import sin, radians

c = Canvas()

for x in range(0, 1800, 10):
    c.set(x / 10, 10 + sin(radians(x)) * 10)

print(c.frame())
```
hoping to get this image:
![](https://raw.githubusercontent.com/asciimoo/drawille/master/docs/images/usage.png)
but got this instead:
```
⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠌⠀⠀⠀⠀⠀⠈⠄⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠌⠀⠀⠀⠀⠀⠐⠄⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠔⠀⠀⠀⠀⠀⠈⠄⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠔⠀⠀⠀⠀⠀⠈⠄⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠌⠀⠀⠀⠀⠀⠈⠄⠀
⢄⠀⠀⠀⠀⠀⠀⠀⢀⠌⠀⠀⠀⠀⠀⠀⠀⠈⢂⠀⠀⠀⠀⠀⠀⠀⢀⠌⠀⠀⠀⠀⠀⠀⠀⠈⢂⠀⠀⠀⠀⠀⠀⠀⢀⠌⠀⠀⠀⠀⠀⠀⠀⠈⢂⠀⠀⠀⠀⠀⠀⠀⢀⠌⠀⠀⠀⠀⠀⠀⠀⠈⢂⠀⠀⠀⠀⠀⠀⠀⢀⠌⠀⠀⠀⠀⠀⠀⠀⠈⠂
⠀⢂⠀⠀⠀⠀⠀⢀⠂⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠢⠀⠀⠀⠀⠀⠠⠂⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠢⠀⠀⠀⠀⠀⢀⠂⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢂⠀⠀⠀⠀⠀⢀⠂⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠢⠀⠀⠀⠀⠀⢀⠂⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
⠀⠀⠑⢄⡀⣀⠔⠁⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠑⢄⡀⣀⠔⠁⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠑⢄⡀⣀⠔⠁⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠑⢄⡀⣀⠔⠁⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠑⢄⡀⣀⠔⠁⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
⠀⠀⠀⠀⠈⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠈⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠈⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠈⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠈⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
```
I'm trying to use libdrawille to add historical graph to [one awesome project](https://github.com/g3t0r/AmIHot), getting the chart right is my first step, then I'll work on coloring and the whole graph math shenanigans, but this is definitely something I'll need to figure out how to fix first.

Thank you for this library.